### PR TITLE
refactor: Map 기반 응답을 DTO로 교체하여 타입 안전성 강화

### DIFF
--- a/src/main/java/com/example/chatapp/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/chatapp/dto/request/LoginRequest.java
@@ -1,0 +1,24 @@
+package com.example.chatapp.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 로그인 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 3, max = 20, message = "사용자명은 3-20자 사이여야 합니다")
+    private String username;
+    
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 6, max = 100, message = "비밀번호는 6자 이상이어야 합니다")
+    private String password;
+}

--- a/src/main/java/com/example/chatapp/dto/request/SignupRequest.java
+++ b/src/main/java/com/example/chatapp/dto/request/SignupRequest.java
@@ -1,0 +1,24 @@
+package com.example.chatapp.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 회원가입 요청 DTO
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupRequest {
+    
+    @NotBlank(message = "사용자명은 필수입니다")
+    @Size(min = 3, max = 20, message = "사용자명은 3-20자 사이여야 합니다")
+    private String username;
+    
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 6, max = 100, message = "비밀번호는 6자 이상이어야 합니다")
+    private String password;
+}

--- a/src/main/java/com/example/chatapp/dto/response/AuthResponse.java
+++ b/src/main/java/com/example/chatapp/dto/response/AuthResponse.java
@@ -1,0 +1,24 @@
+package com.example.chatapp.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+/**
+ * 인증 응답 DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthResponse {
+    
+    private String token;
+    private Long userId;
+    private String username;
+    private Date expiresAt;
+    private boolean valid;
+}


### PR DESCRIPTION
## Summary
- AuthController의 Map<String, Object> 반환 타입을 AuthResponse DTO로 변경하여 타입 안전성 강화
- 입력 검증을 위한 LoginRequest, SignupRequest DTO 추가로 API 안정성 향상
- 코드 중복 제거를 위한 extractAndValidateToken 공통 메서드 추가

## Test plan
- [x] AuthControllerTest를 DTO 기반으로 업데이트하여 일관성 확보
- [x] 모든 API 엔드포인트가 올바른 DTO 타입으로 응답하는지 검증
- [x] @Valid 어노테이션을 통한 자동 입력 검증 동작 확인
- [x] Service 계층에서 AuthResponse DTO를 직접 반환하는 구조 확인

🤖 Generated with [Claude Code](https://claude.ai/code)